### PR TITLE
Feature/formatter json xml

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,10 @@ const items = [
   getItem("Conversão", "conversao", <SettingOutlined />, [
     getItem("Conversor de Texto", "/convert-text", null),
   ]),
+  getItem("Formatador", "formatador", <SettingOutlined />, [
+    getItem("Formatar JSON", "/json-formatter", null),
+    getItem("Formatar XML", "/xml-formatter", null),
+  ]),
   getItem("Gerador", "gerador", <SettingOutlined />, [
     getItem("Gerador de Senha", "/generate-key", null),
     getItem("Gerador de CPF", "/generate-cpf", null),
@@ -104,7 +108,7 @@ function App() {
           </Content>
         </Layout>
       </Content>
-      <Footer style={{ textAlign: 'center' }}>Created by Ananias C. ©2023</Footer>
+      <Footer style={{ textAlign: 'center' }}>Created by Ananias C. ©2025</Footer>
     </Layout>
   );
 }

--- a/src/assets/pages/content/ContentBody.jsx
+++ b/src/assets/pages/content/ContentBody.jsx
@@ -3,6 +3,8 @@ import ConvertText from "../convertText/ConvertText";
 import GenerateKey from "../generateKey/GenerateKey";
 import GenerateCpf from "../generateCpf/GenerateCpf";
 import GenerateCnpj from "../generateCnpj/GenerateCnpj";
+import JsonFormatter from "../jsonFormatter/JsonFormatter";
+import XmlFormatter from "../xmlFormatter/XmlFormatter";
 
 function ContentBody() {
   return ( 
@@ -13,6 +15,8 @@ function ContentBody() {
         <Route path='/generate-key' element={<GenerateKey />}></Route>
         <Route path='/generate-cpf' element={<GenerateCpf />}></Route>
         <Route path='/generate-cnpj' element={<GenerateCnpj />}></Route>
+        <Route path='/json-formatter' element={<JsonFormatter />}></Route>
+        <Route path='/xml-formatter' element={<XmlFormatter />}></Route>
       </Routes>
     </>
   );

--- a/src/assets/pages/jsonFormatter/JsonFormatter.css
+++ b/src/assets/pages/jsonFormatter/JsonFormatter.css
@@ -1,0 +1,17 @@
+@media (min-width: 740px) {
+  .content-body {
+    margin: 0% 20%;
+  }
+  .form-items {
+    width: 43.5vw;
+  }
+}
+
+@media (max-width: 739.98px) {
+  .content-body {
+    margin: 0% 0%;
+  }
+  .form-items {
+    width: 65vw;
+  }
+}

--- a/src/assets/pages/jsonFormatter/JsonFormatter.jsx
+++ b/src/assets/pages/jsonFormatter/JsonFormatter.jsx
@@ -1,0 +1,71 @@
+import './JsonFormatter.css';
+import { useState } from 'react';
+import { Space, Form, Button, message, Row, Col } from "antd";
+import copy from "clipboard-copy";
+import TextArea from 'antd/es/input/TextArea';
+import { CopyOutlined } from "@ant-design/icons";
+
+function JsonFormatter() {
+  const [text, setText] = useState("");
+  const [formattedJson, setFormattedJson] = useState("");
+
+  const handleCopyClick = () => {
+    if (formattedJson) {
+      copy(formattedJson);
+      message.success("JSON copiado para a área de transferência");
+    } else {
+      message.error("Nenhum JSON para copiar");
+    }
+  };
+
+  const formatJson = () => {
+    try {
+      const parsed = JSON.parse(text);
+      setFormattedJson(JSON.stringify(parsed, null, 4));
+    } catch (error) {
+      message.error("JSON inválido");
+    }
+  };
+
+  return (
+    <div className='content-body'>
+      <h1>Formatador de JSON</h1>
+      <Form layout="vertical">
+        <Form.Item label="Cole seu JSON aqui:">
+          <TextArea 
+            className="form-items"
+            placeholder="Cole o JSON aqui..."
+            rows={5}
+            value={text}
+            onChange={(event) => setText(event.target.value)}
+            style={{ borderRadius: '5px' }}
+          />
+        </Form.Item>
+        <Form.Item>
+          <Button type="primary" onClick={formatJson}>Formatar JSON</Button>
+        </Form.Item>
+      </Form>
+
+      <h3 className="margin-h3">JSON Formatado</h3>
+      <Form layout="vertical">
+        <Form.Item>
+          <Space direction="vertical" className='form-items'>
+            <Space.Compact className='form-items'>
+              <TextArea 
+                rows={5}
+                value={formattedJson}
+                readOnly
+                style={{ borderRadius: '5px' }}
+              />
+              <Button type="primary" title="Copiar JSON" onClick={handleCopyClick}>
+                <CopyOutlined/>
+              </Button>
+            </Space.Compact>
+          </Space>
+        </Form.Item>
+      </Form>
+    </div>
+  );
+}
+
+export default JsonFormatter;

--- a/src/assets/pages/xmlFormatter/XmlFormatter.css
+++ b/src/assets/pages/xmlFormatter/XmlFormatter.css
@@ -1,0 +1,17 @@
+@media (min-width: 740px) {
+  .content-body {
+    margin: 0% 20%;
+  }
+  .form-items {
+    width: 43.5vw;
+  }
+}
+
+@media (max-width: 739.98px) {
+  .content-body {
+    margin: 0% 0%;
+  }
+  .form-items {
+    width: 65vw;
+  }
+}

--- a/src/assets/pages/xmlFormatter/XmlFormatter.jsx
+++ b/src/assets/pages/xmlFormatter/XmlFormatter.jsx
@@ -1,0 +1,91 @@
+import './XmlFormatter.css';
+import { useState } from 'react';
+import { Space, Form, Button, message, Row, Col } from "antd";
+import copy from "clipboard-copy";
+import TextArea from 'antd/es/input/TextArea';
+import { CopyOutlined } from "@ant-design/icons";
+
+function XmlFormatter() {
+  const [text, setText] = useState("");
+  const [formattedXml, setFormattedXml] = useState("");
+
+  const handleCopyClick = () => {
+    if (formattedXml) {
+      copy(formattedXml);
+      message.success("XML copiado para a área de transferência");
+    } else {
+      message.error("Nenhum XML para copiar");
+    }
+  };
+
+  const formatXml = () => {
+    try {
+      const parser = new DOMParser();
+      const xml = parser.parseFromString(text, 'application/xml');
+
+      if (xml.getElementsByTagName('parsererror').length) {
+        throw new Error('XML inválido');
+      }
+
+      const serializer = new XMLSerializer();
+      const formattedXml = formatPrettyXml(serializer.serializeToString(xml));
+      setFormattedXml(formattedXml);
+    } catch (error) {
+      message.error("XML inválido");
+    }
+  };
+
+  const formatPrettyXml = (xml) => {
+    const PADDING = '  ';
+    let formatted = '';
+    let pad = 0;
+    xml.split(/>\s*</).forEach((node) => {
+      if (node.match(/^\/\w/)) pad -= 2;
+      formatted += PADDING.repeat(pad) + '<' + node + '>\n';
+      if (node.match(/^<?\w[^>]*[^\/]$/)) pad += 2;
+    });
+    return formatted.trim().slice(1, -1);
+  };
+
+  return (
+    <div className='content-body'>
+      <h1>Formatador de XML</h1>
+      <Form layout="vertical">
+        <Form.Item label="Cole seu XML aqui:">
+          <TextArea 
+            className="form-items"
+            placeholder="Cole o XML aqui..."
+            rows={5}
+            value={text}
+            onChange={(event) => setText(event.target.value)}
+            style={{ borderRadius: '5px' }}
+          />
+        </Form.Item>
+        <Form.Item>
+          <Button type="primary" onClick={formatXml}>Formatar XML</Button>
+        </Form.Item>
+      </Form>
+
+      <h3 className="margin-h3">XML Formatado</h3>
+      <Form layout="vertical">
+        <Form.Item>
+          <Space direction="vertical" className='form-items'>
+            <Space.Compact className='form-items'>
+              <TextArea 
+                rows={5}
+                value={formattedXml}
+                readOnly
+                style={{ borderRadius: '5px' }}
+              />
+              <Button type="primary" title="Copiar XML" onClick={handleCopyClick}>
+                <CopyOutlined/>
+              </Button>
+            </Space.Compact>
+          </Space>
+        </Form.Item>
+      </Form>
+    </div>
+  );
+}
+
+export default XmlFormatter;


### PR DESCRIPTION
### **JSON Formatter Page**  
The JSON Formatter page provides a user-friendly interface to format and validate JSON input. Users can paste unformatted JSON, and with a single click, the tool will indent and structure the data properly. If the input is invalid, an error message will be displayed. Additionally, the formatted JSON can be copied to the clipboard for convenience.  

**Features:**  
- JSON validation  
- Pretty-print JSON formatting  
- Copy formatted JSON to clipboard  

---

### **XML Formatter Page**  
The XML Formatter page allows users to format and beautify XML code. By pasting raw or unstructured XML, users can format it with proper indentation. The tool also validates the XML and removes unnecessary characters. Users can copy the formatted XML with a single click.  

**Features:**  
- XML validation  
- Pretty-print XML formatting  
- Copy formatted XML to clipboard  